### PR TITLE
Remove ability to create a "job run"

### DIFF
--- a/src/app/UI/lib/managers/administration/client/components/sections/job/routes.js
+++ b/src/app/UI/lib/managers/administration/client/components/sections/job/routes.js
@@ -60,12 +60,6 @@ const routes = (
             icon="assignment"
         >
             <Route
-                path="create"
-                component={TAEdit}
-                Create={JobEdit}
-                type="exec.job"
-            />
-            <Route
                 path=":_id"
                 component={TAView}
                 Item={JobItem}


### PR DESCRIPTION
The backend doesn't allow the UI to do this, due to missing required information and it does not really make sense to do it anyway.